### PR TITLE
Remove react-native-worklets

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,19 +15,13 @@ npm install
 (cd ios && bundle install && bundle exec pod install)
 ```
 
-The project uses [react-native-worklets](https://docs.swmansion.com/react-native-worklets/) together with [react-native-reanimated](https://docs.swmansion.com/react-native-reanimated/). If Metro complains about worklets when you run the app, rebuild and restart Metro with a cleared cache:
+The project uses [react-native-reanimated](https://docs.swmansion.com/react-native-reanimated/) for animations. If Metro complains about worklets when you run the app, rebuild and restart Metro with a cleared cache:
 
 ```sh
 npx react-native start --reset-cache
 ```
 
-Worklets must be initialized before Reanimated. The default `index.js` already
-imports `react-native-worklets` followed by `react-native-reanimated`:
 
-```javascript
-import 'react-native-worklets';
-import 'react-native-reanimated';
-```
 
 ## Step 1: Start Metro
 

--- a/__tests__/App.test.tsx
+++ b/__tests__/App.test.tsx
@@ -41,7 +41,6 @@ jest.mock('react-native-reanimated', () => {
   return Reanimated;
 });
 
-jest.mock('react-native-worklets', () => ({}), {virtual: true});
 
 jest.mock('@react-native-async-storage/async-storage', () => ({
   __esModule: true,

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,4 +1,4 @@
 module.exports = {
   presets: ['module:@react-native/babel-preset'],
-  plugins: ['react-native-worklets/plugin'],
+  plugins: ['react-native-reanimated/plugin'],
 };

--- a/index.js
+++ b/index.js
@@ -2,7 +2,6 @@
  * @format
  */
 
-import 'react-native-worklets';
 import 'react-native-reanimated';
 import { AppRegistry } from 'react-native';
 import App from './App';

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,7 +1,7 @@
 module.exports = {
   preset: 'react-native',
   transformIgnorePatterns: [
-    'node_modules/(?!(react-native|@react-native|react-native-reanimated|react-native-worklets|react-native-svg)/)',
+    'node_modules/(?!(react-native|@react-native|react-native-reanimated|react-native-svg)/)',
   ],
   setupFiles: ['./jest.setup.js'],
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,9 +18,7 @@
         "react-native-audio-record": "^0.2.2",
         "react-native-linear-gradient": "^2.8.3",
         "react-native-reanimated": "^3.19.0",
-        "react-native-svg": "^15.12.0",
-        "react-native-worklets": "0.4.0",
-        "react-native-worklets-core": "1.6.0"
+        "react-native-svg": "^15.12.0"
       },
       "devDependencies": {
         "@babel/core": "^7.25.2",
@@ -10030,42 +10028,6 @@
         "react-native": "*"
       }
     },
-    "node_modules/react-native-worklets": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/react-native-worklets/-/react-native-worklets-0.4.0.tgz",
-      "integrity": "sha512-q4AKd9RH6JSX17dSbXw1ppr7WbGYleQT2GqlpE9LLKLRAi2UeSHD3Q3br4MBGobQfQDyfDyfkiO5DvhXSa/8Xg==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/plugin-transform-arrow-functions": "^7.0.0-0",
-        "@babel/plugin-transform-class-properties": "^7.0.0-0",
-        "@babel/plugin-transform-classes": "^7.0.0-0",
-        "@babel/plugin-transform-nullish-coalescing-operator": "^7.0.0-0",
-        "@babel/plugin-transform-optional-chaining": "^7.0.0-0",
-        "@babel/plugin-transform-shorthand-properties": "^7.0.0-0",
-        "@babel/plugin-transform-template-literals": "^7.0.0-0",
-        "@babel/plugin-transform-unicode-regex": "^7.0.0-0",
-        "@babel/preset-typescript": "^7.16.7",
-        "convert-source-map": "^2.0.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0",
-        "react": "*",
-        "react-native": "*"
-      }
-    },
-    "node_modules/react-native-worklets-core": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/react-native-worklets-core/-/react-native-worklets-core-1.6.0.tgz",
-      "integrity": "sha512-IRu8UUROsRklFdeqmZdWxeCq+EYYSCV8zj4S9mdPwm1K72OehptoYbZCU3+2NjINF4I8Q+Z+z5TwaJQpKQBYmg==",
-      "license": "MIT",
-      "dependencies": {
-        "string-hash-64": "^1.0.3"
-      },
-      "peerDependencies": {
-        "react": "*",
-        "react-native": "*"
-      }
-    },
     "node_modules/react-native/node_modules/ansi-styles": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
@@ -10887,12 +10849,6 @@
       "dependencies": {
         "safe-buffer": "~5.2.0"
       }
-    },
-    "node_modules/string-hash-64": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string-hash-64/-/string-hash-64-1.0.3.tgz",
-      "integrity": "sha512-D5OKWKvDhyVWWn2x5Y9b+37NUllks34q1dCDhk/vYcso9fmhs+Tl3KR/gE4v5UNj2UA35cnX4KdVVGkG1deKqw==",
-      "license": "MIT"
     },
     "node_modules/string-length": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -20,9 +20,7 @@
     "react-native-audio-record": "^0.2.2",
     "react-native-linear-gradient": "^2.8.3",
     "react-native-reanimated": "^3.19.0",
-    "react-native-svg": "^15.12.0",
-    "react-native-worklets": "0.4.0",
-    "react-native-worklets-core": "1.6.0"
+    "react-native-svg": "^15.12.0"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",


### PR DESCRIPTION
## Summary
- drop `react-native-worklets` packages and imports causing build conflicts
- use the Reanimated Babel plugin
- update Jest config and tests
- refresh lockfile
- clean up README instructions

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68822f81aa9083318ab78e5ae85224a5