### PR TITLE
Add helper script for Android build

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,9 @@ With Metro running, open a new terminal window/pane from the root of your React 
 
 ### Android
 
+Run `./run_android.sh` to start Metro and launch the Android emulator. Use `./run_android.sh apk` to build a release APK.
+
+
 ```sh
 # Using npm
 npm run android

--- a/run_android.sh
+++ b/run_android.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+    echo "Usage: $0 [apk]"
+    echo "  Without args: start Metro and launch the Android emulator"
+    echo "  apk         : build release APK"
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+    usage
+    exit 0
+fi
+
+if [[ "${1:-}" == "apk" ]]; then
+    echo "Building release APK..."
+    (cd android && ./gradlew assembleRelease)
+    echo "APK generated at android/app/build/outputs/apk/release/app-release.apk"
+    exit 0
+fi
+
+if ! command -v adb >/dev/null; then
+    echo "Error: adb not found. Please install Android platform tools." >&2
+    exit 1
+fi
+
+METRO_PID=""
+if ! lsof -i:8081 >/dev/null 2>&1; then
+    echo "Starting Metro bundler..."
+    npx react-native start --reset-cache &
+    METRO_PID=$!
+    # give Metro some time to start
+    sleep 3
+fi
+
+cleanup() {
+    if [[ -n "$METRO_PID" ]]; then
+        kill "$METRO_PID" 2>/dev/null || true
+    fi
+}
+trap cleanup EXIT
+
+npx react-native run-android


### PR DESCRIPTION
## Summary
- add `run_android.sh` for launching emulator and building release APK
- document script usage in README

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_688235afc8608331a7bc6ce16adc4f41